### PR TITLE
Auto reload when either template or target property file changes

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -60,4 +60,8 @@ Simplify your property file management, boost productivity, and effortlessly rep
             <add-to-group group-id="NewGroup"/>
         </action>
     </actions>
+    <applicationListeners>
+        <listener class="com.github.nizienko.propertiesSwitcher.PropertySwitcherListener"
+                  topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"/>
+    </applicationListeners>
 </idea-plugin>


### PR DESCRIPTION
Very simple implementation of auto-reloading of template and property files.  Fixes #8 and #10.

This implementation is pretty inefficient as it basically calls `reload()` whenever it detects a change within one of the property files that is referenced by any template or whenever there's a change to any template within project content. In order to make it better, some major refactoring of plugin is required: ability to track / reload individual templates.